### PR TITLE
Fixed box height with firefox.

### DIFF
--- a/style.css
+++ b/style.css
@@ -253,7 +253,7 @@ a:active {
 .advanced-settings-box {
 	clear: both;
 	width: 100%;
-	height: 110px;
+	height: 130px;
 	background-color: rgba(255,255,255,0.15);
 	border-radius: 5px;
 	padding-top: 2px;


### PR DESCRIPTION
On Firefox, the advanced settings box doesn't have the correct height:
![image](https://user-images.githubusercontent.com/950594/170536813-7b28f048-6afc-4162-933f-d110a9eb6fa5.png)
Changes it to be like this now:
![image](https://user-images.githubusercontent.com/950594/170536888-950ec951-0880-4504-aa3c-7ad359e4fa96.png)
Still looks normal on Chrome.